### PR TITLE
Build Configuration By Environment

### DIFF
--- a/TheBench.Api/Program.cs
+++ b/TheBench.Api/Program.cs
@@ -29,21 +29,10 @@ builder.Services.AddCors(options =>
     });
 });
 
-var apiConfiguration = builder.Configuration.GetSection("ApiConfiguration").Get<ApiConfiguration>();
-if (apiConfiguration == null)
-{
-    throw new InvalidOperationException("API configuration is missing or invalid.");
-}
+var serviceConfiguration = LoadConfiguration(builder);
 
-var mailGunConfig = builder.Configuration.GetSection("MailGunConfig").Get<MailGunConfiguration>();
-if (mailGunConfig == null)
-{
-    throw new InvalidOperationException("MailGun configuration is missing or invalid.");
-}
-mailGunConfig.SetApiKey(Environment.GetEnvironmentVariable("MAILGUN_API_KEY")!);
-
-builder.Services.AddSingleton(apiConfiguration);
-builder.Services.AddSingleton(mailGunConfig);
+builder.Services.AddSingleton(serviceConfiguration);
+builder.Services.AddSingleton(serviceConfiguration.MailGunConfiguration);
 builder.Services.AddDbContext<UserContext>();
 builder.Services.AddScoped<IUserAdapter, UserAdapter>();
 builder.Services.AddScoped<ITeamAdapter, TeamAdapter>();
@@ -69,3 +58,37 @@ app.UseCors("AllowFrontend");
 app.MapControllers();
 
 app.Run();
+return;
+
+static ApiConfiguration LoadConfiguration(WebApplicationBuilder builder)
+{
+    var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Development";
+    if (env == "Development")
+    {
+        Console.WriteLine("Loading configuration from appsettings.json");
+        var config = builder.Configuration.GetSection("ApiConfiguration").Get<ApiConfiguration>() 
+               ?? throw new InvalidOperationException("API configuration is missing or invalid.");
+        Console.WriteLine($"Config: {config}");
+        return config;
+    }
+    
+    var baseUiUri = Environment.GetEnvironmentVariable("BASE_UI_URI") 
+                    ?? throw new InvalidOperationException("Base UI URL is not set in environment variables.");
+    var databaseConnectionString = Environment.GetEnvironmentVariable("DATABASE_URL") 
+                                   ?? throw new InvalidOperationException("Database connection string is not set in environment variables.");
+    var mailgunBaseUri = Environment.GetEnvironmentVariable("MAILGUN_BASE_URI") 
+                         ?? throw new InvalidOperationException("Mailgun base URI is not set in environment variables.");
+    var mailgunDomain = Environment.GetEnvironmentVariable("MAILGUN_DOMAIN") 
+                        ?? throw new InvalidOperationException("Mailgun domain is not set in environment variables.");
+    var mailgunApiKey = Environment.GetEnvironmentVariable("MAILGUN_API_KEY") 
+                        ?? throw new InvalidOperationException("Mailgun API key is not set in environment variables.");
+    
+    var mailGunConfig = new MailGunConfiguration
+    {
+        BaseUri = mailgunBaseUri,
+        Domain = mailgunDomain,
+        ApiKey = mailgunApiKey
+    };
+    
+    return new ApiConfiguration(baseUiUri,databaseConnectionString,mailGunConfig);
+}

--- a/TheBench.Api/Program.cs
+++ b/TheBench.Api/Program.cs
@@ -58,7 +58,6 @@ app.UseCors("AllowFrontend");
 app.MapControllers();
 
 app.Run();
-return;
 
 static ApiConfiguration LoadConfiguration(WebApplicationBuilder builder)
 {

--- a/TheBench.Api/appsettings.Development.json
+++ b/TheBench.Api/appsettings.Development.json
@@ -5,12 +5,13 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "DATABASE_URL": "Server=localhost;Port=5432;Database=TheBenchDB;User Id=docker;Password=docker_pw",
-  "MailGunConfig": {
-    "BaseUri": "https://api.mailgun.net/v3",
-    "Domain": "the-bench.us"
-  },
   "ApiConfiguration": {
-    "BaseUiUri": "http://localhost:5173"
+    "BaseUiUri": "http://localhost:5173",
+    "DatabaseConnectionString": "Server=localhost;Port=5432;Database=TheBenchDB;User Id=docker;Password=docker_pw",
+    "MailGunConfiguration": {
+      "BaseUri": "https://api.mailgun.net/v3",
+      "Domain": "the-bench.us",
+      "ApiKey": ""
+    }
   }
 }

--- a/TheBench.Api/appsettings.Production.json
+++ b/TheBench.Api/appsettings.Production.json
@@ -5,12 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "MailGunConfig": {
-    "BaseUri": "https://api.mailgun.net/v3",
-    "Domain": "the-bench.us"
-  },
-  "ApiConfiguration": {
-    "BaseUiUri": "https://the-bench-ui-185160f67ef3.herokuapp.com"
-  },
   "AllowedHosts": "*"
 }

--- a/TheBench.Logic/Config/ApiConfiguration.cs
+++ b/TheBench.Logic/Config/ApiConfiguration.cs
@@ -1,5 +1,7 @@
 namespace TheBench.Logic.Config;
 
 public record ApiConfiguration(
-    string BaseUiUri = ""
+    string BaseUiUri,
+    string DatabaseConnectionString,
+    MailGunConfiguration MailGunConfiguration
     );

--- a/TheBench.Logic/Config/MailGunConfiguration.cs
+++ b/TheBench.Logic/Config/MailGunConfiguration.cs
@@ -4,9 +4,4 @@ public record MailGunConfiguration(
     string BaseUri = "",
     string Domain = "",
     string ApiKey = ""
-)
-{
-    public string ApiKey { get; private set; } = ApiKey;
-
-    public void SetApiKey(string key) => ApiKey = key;
-};
+);


### PR DESCRIPTION
This commit changes the way the configuration values are loaded. Since Heroku relies on env variables, we will load the necessary config values from the env. Otherwise, in development mode, we will just use the appsettings config to make it a bit easier